### PR TITLE
Add CODEOWNERS file for GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ikeycode


### PR DESCRIPTION
Together with a `branch protection rule` like this, it would cause an automatic notification for the code owner (in this case Ikey) and require him to approve before it can be merged.
Can always be overridden by repo admins.
![screenshot-20230411-200838](https://user-images.githubusercontent.com/10406217/231252183-2ca4159e-dc5e-4e81-a906-dd307bdc44f1.png)
