### PR TITLE
gitattributes: allow GitHub to correctly detect primary language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+subprojects/** linguist-vendored
+vendor/** linguist-vendored


### PR DESCRIPTION
As shown here: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#vendored-code

Before:
![image](https://github.com/serpent-os/libmoss/assets/74938940/95992bc6-60c9-4cdc-a2da-f5d099bdb1e0)
After:
![image](https://github.com/serpent-os/libmoss/assets/74938940/1630adb8-0d84-4f50-b6ef-4b5459cbcd86)
